### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Build
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   # push:


### PR DESCRIPTION
Potential fix for [https://github.com/revgrid/revgrid/security/code-scanning/1](https://github.com/revgrid/revgrid/security/code-scanning/1)

In general, the fix is to explicitly declare a `permissions` block that limits the `GITHUB_TOKEN` to the least privilege required. For this workflow, the steps only read the source code and run local Node commands; they do not need to write to the repository or modify other GitHub resources. Therefore, we can safely set `contents: read` as the global workflow permission, applied to all jobs.

The best fix without changing existing functionality is to add a top-level `permissions` section after the `name:` (or after `on:`) that specifies `contents: read`. This will apply to the `build` job since it has no job-specific permissions. No additional imports or dependencies are needed; this is a pure YAML configuration change within `.github/workflows/build.yml`.

Concretely, in `.github/workflows/build.yml`, insert:

```yaml
permissions:
  contents: read
```

at the root level (same indentation as `name` and `on`) between `name: Build` and `on:` (or between `on:` and `jobs:` if you prefer). No other lines need to change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
